### PR TITLE
Fix favicon encoding in Portal template

### DIFF
--- a/helm/portal/templates/secret.yaml
+++ b/helm/portal/templates/secret.yaml
@@ -19,7 +19,7 @@ data:
   {{- end }}
   {{- if .Values.gitops.favicon }}
   gitops-favicon.ico: |
-    {{- .Values.gitops.favicon | b64enc | nindent 4 }}
+    {{- .Values.gitops.favicon | nindent 4 }}
   {{- else }}
   gitops-favicon.ico: |
     {{- (.Files.Get "defaults/gitops-favicon.ico" ) | nindent 4 }}


### PR DESCRIPTION
This PR fixes the issue where the favicon was not being displayed correctly due to being double encoded in base64 