### PR TITLE
Add resource policy to keep ALB ingress controller

### DIFF
--- a/helm/revproxy/templates/ingress_aws.yaml
+++ b/helm/revproxy/templates/ingress_aws.yaml
@@ -10,6 +10,7 @@ metadata:
     alb.ingress.kubernetes.io/group.name: {{ .Values.global.environment }}
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS":443}]'
     alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
+    helm.sh/resource-policy: keep
 spec:
   ingressClassName: alb
   rules:


### PR DESCRIPTION
Prevents the Load Balancer from being discarded between deployments (thus requiring updating the DNS record in the domain registrar).