### PR TITLE
fix `make push-secrets ENV=cbds-dev` failing

### DIFF
--- a/SSClient.py
+++ b/SSClient.py
@@ -64,14 +64,12 @@ def conv_shorthand(env: str) -> str:
         return "development"
     if env == "prod":
         return "production"
-    if env == "cbds-dev":
-        return "cbds_dev"
+    
     return env
 
 
 def match_env_with_id(env: str, id: Optional[int]):
     "Associates environment secret with its SS ID"
-
     conv_env = conv_shorthand(env)
     prefix = "Secrets-"
     if id is not None:
@@ -90,7 +88,9 @@ def match_env_with_id(env: str, id: Optional[int]):
     if conv_env in ["cbds", "CBDS"]:
         return SECRETS_CBDS, f"{prefix}cbds"
     if conv_env in ["cbds-dev", "CBDS-DEV"]:
-        return SECRETS_CBDS_DEV, f"{prefix}cbds_dev"
+        return SECRETS_CBDS_DEV, f"{prefix}cbds-dev"
+    
+    raise Exception(f"no matching environment found for {conv_env} \nSee the Makefile for supported ENV keywords")
 
 
 def _fetch_cached_token() -> str:

--- a/etl.yaml
+++ b/etl.yaml
@@ -29,7 +29,7 @@ spec:
 
   containers:
     - name: container-configmap
-      image: quay.io/ohsu-comp-bio/aced-etl:feature_grip
+      image: quay.io/ohsu-comp-bio/aced-etl:development
       imagePullPolicy: Always
       volumeMounts:
         # Gen3 credentials file

--- a/helm/indexd/templates/pre-install.yaml
+++ b/helm/indexd/templates/pre-install.yaml
@@ -81,7 +81,9 @@ spec:
             - "-c"
             # Script always succeeds if it runs (echo exits with 0)
             # indexd image does not include jq, so use python 
+            # TODO: revert source activate after resolution with upstream
             - |
+              source .venv/bin/activate
               echo 'python /indexd/bin/index_admin.py create --username "fence" --password "${FENCE_PASS}'
               python /indexd/bin/index_admin.py create --username "fence" --password "${FENCE_PASS}"
               echo 'python /indexd/bin/index_admin.py create --username "sheepdog" --password "${SHEEPDOG_PASS}'


### PR DESCRIPTION
Make sure it points to the Secrets-cbds-dev directory so you can correctly execute
```make push-secrets ENV=cbds-dev```


Steps to test:
```sh
scp -r cbds-dev:/cbds/gen3-helm/Secrets-cbds-dev path/to/gen3-helm
make push-secrets ENV=cbds-dev
```